### PR TITLE
Small typing cleanup.

### DIFF
--- a/packages/module-detective/src/lib/report.ts
+++ b/packages/module-detective/src/lib/report.ts
@@ -110,7 +110,6 @@ export default function Report(
         }),
       ],
     });
-    console.log("dev server", process.env.DEV_SERVER);
     if (process.env.DEV_SERVER) {
       const server = new WebpackDevServer(
         {

--- a/packages/module-detective/src/types.ts
+++ b/packages/module-detective/src/types.ts
@@ -1,9 +1,43 @@
+export type BasicJSON = Record<string, string>;
+
+// a very weak definition for https://github.com/npm/arborist/blob/48eb8fa01ea1cd1f89f47379b1ba4881a8bb9fbc/lib/node.js
+export interface ArboristNode {
+  children: Map<string, ArboristNode>;
+  dev: boolean;
+  devOptional: boolean;
+  dummy: boolean;
+  edgesIn: Set<ArboristNode>;
+  edgesOut: Map<string, ArboristNode>;
+  errors: Array<any>;
+  extraneous: boolean;
+  fsChildren: Set<ArboristNode>;
+  hasShrinkwrap: boolean;
+  integrity: unknown | null;
+  inventory: Map<string, ArboristNode>;
+  legacyPeerDeps: boolean;
+  linksIn: Set<ArboristNode>;
+  location: string;
+  name: string;
+  optional: boolean;
+  path: string;
+  peer: string;
+  realpath: string;
+  resolved: unknown | null;
+  sourceReference: unknown | null;
+  tops: Set<ArboristNode>;
+  package: BasicJSON;
+  packageName: string;
+  isLink: boolean;
+  homepage: string;
+  funding: string;
+}
+
 export interface IDependency {
   name: string;
   breadcrumb: string;
   size: number;
   location: string;
-  packageInfo: any;
+  packageInfo: BasicJSON;
   // url to dependecy
   homepage?: string;
   // funding url
@@ -20,6 +54,10 @@ export interface IActionMeta {
   size?: number;
 }
 
+export interface IVersionMeta extends IActionMeta {
+  version: string;
+}
+
 export interface IAction {
   message: string;
   meta: IActionMeta;
@@ -34,7 +72,7 @@ export interface ISuggestion {
 
 export interface IReport {
   latestPackages: any;
-  package: any;
+  package: BasicJSON;
   dependencies: [string, Omit<IDependency, "packageInfo">][];
   suggestions: ISuggestion[];
 }

--- a/packages/module-detective/src/types.ts
+++ b/packages/module-detective/src/types.ts
@@ -1,21 +1,22 @@
 export type BasicJSON = Record<string, string>;
+export type DependenciesList = [string, IDependency][];
 
 // a very weak definition for https://github.com/npm/arborist/blob/48eb8fa01ea1cd1f89f47379b1ba4881a8bb9fbc/lib/node.js
-export interface ArboristNode {
-  children: Map<string, ArboristNode>;
+export interface IArboristNode {
+  children: Map<string, IArboristNode>;
   dev: boolean;
   devOptional: boolean;
   dummy: boolean;
-  edgesIn: Set<ArboristNode>;
-  edgesOut: Map<string, ArboristNode>;
+  edgesIn: Set<IArboristNode>;
+  edgesOut: Map<string, IArboristNode>;
   errors: Array<any>;
   extraneous: boolean;
-  fsChildren: Set<ArboristNode>;
+  fsChildren: Set<IArboristNode>;
   hasShrinkwrap: boolean;
   integrity: unknown | null;
-  inventory: Map<string, ArboristNode>;
+  inventory: Map<string, IArboristNode>;
   legacyPeerDeps: boolean;
-  linksIn: Set<ArboristNode>;
+  linksIn: Set<IArboristNode>;
   location: string;
   name: string;
   optional: boolean;
@@ -24,7 +25,7 @@ export interface ArboristNode {
   realpath: string;
   resolved: unknown | null;
   sourceReference: unknown | null;
-  tops: Set<ArboristNode>;
+  tops: Set<IArboristNode>;
   package: BasicJSON;
   packageName: string;
   isLink: boolean;
@@ -37,7 +38,6 @@ export interface IDependency {
   breadcrumb: string;
   size: number;
   location: string;
-  packageInfo: BasicJSON;
   // url to dependecy
   homepage?: string;
   // funding url
@@ -71,8 +71,8 @@ export interface ISuggestion {
 }
 
 export interface IReport {
-  latestPackages: any;
+  latestPackages: BasicJSON;
   package: BasicJSON;
-  dependencies: [string, Omit<IDependency, "packageInfo">][];
+  dependencies: DependenciesList;
   suggestions: ISuggestion[];
 }


### PR DESCRIPTION
I did a few things:
1. Added an `IArboristNode` interface to give some information about the object that comes out of arborist.
2. Added `BasicJSON = Record<string, string>;`.
3. Added  `DependenciesList = [string, IDependency][];`
4. Moved `IVersionMeta` to `types.ts`

These aren't _great_, but better than nothing, and it will be easier to improve once we have something.

I also tightened up the `generateReport` function a little, and used the `package` from the `IArboristNode` instead of needing `packageInfo`.

