### PR TITLE
Refactor + Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "root",
+      "dependencies": {
+        "package-json-type": "^1.0.3"
+      },
       "devDependencies": {
         "husky": "^7.0.0",
         "lerna": "^4.0.0"
@@ -5857,6 +5860,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-json-type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/package-json-type/-/package-json-type-1.0.3.tgz",
+      "integrity": "sha512-Bey4gdRuOwDbS8Fj1qA3/pTq5r8pqiI5E3tjSqCdhaLSsyGG364VFzXLTIexN5AaNGe/vgdBzLfoKdr7EVg2KQ=="
     },
     "node_modules/pacote": {
       "version": "11.3.5",
@@ -12208,6 +12216,11 @@
       "requires": {
         "p-reduce": "^2.0.0"
       }
+    },
+    "package-json-type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/package-json-type/-/package-json-type-1.0.3.tgz",
+      "integrity": "sha512-Bey4gdRuOwDbS8Fj1qA3/pTq5r8pqiI5E3tjSqCdhaLSsyGG364VFzXLTIexN5AaNGe/vgdBzLfoKdr7EVg2KQ=="
     },
     "pacote": {
       "version": "11.3.5",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "husky": "^7.0.0",
     "lerna": "^4.0.0"
+  },
+  "dependencies": {
+    "package-json-type": "^1.0.3"
   }
 }

--- a/packages/module-detective/src/lib/dependencies.ts
+++ b/packages/module-detective/src/lib/dependencies.ts
@@ -9,11 +9,13 @@ import { getDirectorySize } from "./utils/disk";
 
 import { IReport, IArboristNode, DependenciesList } from "../types";
 import { IDependencyMap } from "package-json-type";
-import { topLevelDepsFreshness } from "./suggestors/top-level-deps-freshness";
-import { nestedDependencyFreshness } from "./suggestors/nested-deps-freshness";
-import { notBeingAbsorbedByTopLevel } from "./suggestors/not-absorbed-by-top-level";
-import { packagesWithExtraArtifacts } from "./suggestors/packages-with-artifacts";
-import { packagesWithPinnedVersions } from "./suggestors/packages-with-pinned-versions";
+import {
+  topLevelDepsFreshness,
+  nestedDependencyFreshness,
+  notBeingAbsorbedByTopLevel,
+  packagesWithExtraArtifacts,
+  packagesWithPinnedVersions,
+} from "./suggestors";
 
 debug("module-detective");
 

--- a/packages/module-detective/src/lib/dependencies.ts
+++ b/packages/module-detective/src/lib/dependencies.ts
@@ -1,24 +1,19 @@
 import tmp from "tmp";
 import path from "path";
-import fs from "fs";
 import debug from "debug";
 import { exec } from "child_process";
-import semverDiff from "semver/functions/diff";
 import { copyFile, writeFile } from "fs/promises";
 
-import humanFileSize from "./utils/human-file-size";
 import { getBreadcrumb } from "./utils/breadcrumb";
 import { getDirectorySize } from "./utils/disk";
 
-import {
-  IAction,
-  IVersionMeta,
-  IReport,
-  ISuggestion,
-  IArboristNode,
-  DependenciesList,
-} from "../types";
+import { IReport, IArboristNode, DependenciesList } from "../types";
 import { IDependencyMap } from "package-json-type";
+import { topLevelDepsFreshness } from "./suggestors/top-level-deps-freshness";
+import { nestedDependencyFreshness } from "./suggestors/nested-deps-freshness";
+import { notBeingAbsorbedByTopLevel } from "./suggestors/not-absorbed-by-top-level";
+import { packagesWithExtraArtifacts } from "./suggestors/packages-with-artifacts";
+import { packagesWithPinnedVersions } from "./suggestors/packages-with-pinned-versions";
 
 debug("module-detective");
 
@@ -29,386 +24,6 @@ function getValues(dependencyTree: IArboristNode) {
   return [...dependencyTree.inventory.values()].filter(
     (node) => node.location !== ""
   );
-}
-
-// TODO: the type of dependencyTree should come from npm/aborist
-function packagesWithPinnedVersions(
-  dependencyTree: IArboristNode
-): ISuggestion {
-  const packagedWithPinned = [];
-
-  for (const node of getValues(dependencyTree)) {
-    const breadcrumb = getBreadcrumb(node);
-
-    const { dependencies } = node.package ?? {};
-    for (const dependencyName in dependencies) {
-      if (
-        // might need to check the logic on this; "~" means "takes patches"
-        // check node-semver to see the logc
-        dependencies[dependencyName].substring(0, 1) === "~"
-      ) {
-        try {
-          const size = getDirectorySize({
-            directory: node.edgesOut.get(dependencyName)?.to.path ?? "",
-            exclude: new RegExp(path.resolve(node.path, "docs")),
-          });
-
-          packagedWithPinned.push({
-            message: `"${node.name}" (${breadcrumb}) has a pinned version for ${dependencyName}@${dependencies[dependencyName]} that will never collapse.`,
-            meta: {
-              breadcrumb,
-              name: node.name,
-              directory: node.path,
-              size,
-            },
-          });
-        } catch (ex: any) {
-          console.log(ex.message);
-        }
-      }
-    }
-  }
-
-  return {
-    id: "packagesWithPinnedVersions",
-    name: "Packages with pinned dependencies",
-    message: `There are currently ${
-      new Set(packagedWithPinned.map((action) => action.meta.name)).size
-    } packages with pinned versions which will never collapse those dependencies causing an additional ${humanFileSize(
-      packagedWithPinned.reduce((total, dep) => total + dep.meta.size, 0)
-    )}`,
-    actions: packagedWithPinned.sort((a, b) => b.meta.size - a.meta.size),
-  };
-}
-
-function packagesWithExtraArtifacts(
-  dependencyTree: IArboristNode
-): ISuggestion {
-  const extraArtifacts = [];
-
-  for (const node of getValues(dependencyTree)) {
-    const breadcrumb = getBreadcrumb(node);
-
-    if (fs.existsSync(path.resolve(node.path, "docs"))) {
-      const size = getDirectorySize({
-        directory: node.path,
-        exclude: new RegExp(path.resolve(node.path, "docs")),
-      });
-
-      extraArtifacts.push({
-        message: `"${
-          node.name
-        }" (${breadcrumb}) has a "docs" folder which is not necessary for production usage ${humanFileSize(
-          size
-        )}.`,
-        meta: {
-          breadcrumb,
-          name: node.name,
-          directory: node.path,
-          size,
-        },
-      });
-    }
-
-    if (fs.existsSync(path.resolve(node.path, "tests"))) {
-      const size = getDirectorySize({
-        directory: node.path,
-        exclude: new RegExp(path.resolve(node.path, "tests")),
-      });
-
-      extraArtifacts.push({
-        message: `"${
-          node.name
-        }" (${breadcrumb}) has a "tests" folder which is not necessary for production usage ${humanFileSize(
-          size
-        )}.`,
-        meta: {
-          breadcrumb,
-          name: node.name,
-          directory: node.path,
-          size,
-        },
-      });
-    }
-  }
-
-  return {
-    id: "packagesWithExtraArtifacts",
-    name: "Packages with extra artifacts",
-    message: `There are currently ${
-      new Set(extraArtifacts.map((action) => action.meta.name)).size
-    } packages with artifacts that are superflous and are not necessary for production usage. ${humanFileSize(
-      extraArtifacts.reduce((total, dep) => total + dep.meta.size, 0)
-    )}`,
-    actions: extraArtifacts.sort((a, b) => b.meta.size - a.meta.size),
-  };
-}
-
-function topLevelDepsFreshness(
-  dependencyTree: IArboristNode,
-  latestPackages: IDependencyMap
-): ISuggestion {
-  const dependencies = Object.assign(
-    {},
-    Object.assign({}, dependencyTree.package.devDependencies || {}),
-    dependencyTree.package.dependencies || {}
-  );
-  const totalDeps = Object.keys(dependencies).length;
-  const outOfDate: {
-    major: IVersionMeta[];
-    minor: IVersionMeta[];
-    patch: IVersionMeta[];
-  } = { major: [], minor: [], patch: [] };
-
-  for (const dependency in dependencies) {
-    try {
-      const topLevelPackage = [...getValues(dependencyTree)].find(
-        (dependency) => dependency.location === `node_modules/${dependency}`
-      );
-      if (topLevelPackage) {
-        const breadcrumb = getBreadcrumb(topLevelPackage);
-        const diff = semverDiff(
-          topLevelPackage.version,
-          latestPackages[topLevelPackage.name]
-        );
-
-        switch (diff) {
-          case "major":
-            outOfDate.major.push({
-              name: dependency,
-              directory: `node_module/${dependency}`,
-              version: topLevelPackage.version,
-              breadcrumb,
-            });
-            break;
-          case "minor":
-            outOfDate.minor.push({
-              name: dependency,
-              directory: `node_module/${dependency}`,
-              version: topLevelPackage.version,
-              breadcrumb,
-            });
-            break;
-          case "patch":
-            outOfDate.patch.push({
-              name: dependency,
-              directory: `node_module/${dependency}`,
-              version: topLevelPackage.version,
-              breadcrumb,
-            });
-            break;
-        }
-      }
-    } catch (ex) {
-      // TODO: better debugging messaging here
-      console.log(ex);
-    }
-  }
-
-  const actions: IAction[] = [];
-
-  outOfDate.major.forEach(({ name, directory, version, breadcrumb }) => {
-    actions.push({
-      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a major version out of date.`,
-      meta: {
-        name,
-        directory,
-        breadcrumb,
-      },
-    });
-  });
-
-  outOfDate.minor.forEach(({ name, directory, version, breadcrumb }) => {
-    actions.push({
-      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a minor version out of date.`,
-      meta: {
-        name,
-        directory,
-        breadcrumb,
-      },
-    });
-  });
-
-  outOfDate.patch.forEach(({ name, directory, version, breadcrumb }) => {
-    actions.push({
-      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a patch version out of date.`,
-      meta: {
-        name,
-        directory,
-        breadcrumb,
-      },
-    });
-  });
-
-  return {
-    id: "topLevelDepsFreshness",
-    name: "Top Level Dependency Freshness",
-    message: `Out of the total ${totalDeps} explicit dependencies defined in the package.json; ${
-      outOfDate.major.length
-    } major versions out of date (${(
-      (outOfDate.major.length / totalDeps) *
-      100
-    ).toFixed(2)}%), ${outOfDate.minor.length} minor versions out of date (${(
-      (outOfDate.minor.length / totalDeps) *
-      100
-    ).toFixed(2)}%), ${outOfDate.patch.length} patch versions out of date (${(
-      (outOfDate.patch.length / totalDeps) *
-      100
-    ).toFixed(2)}%)`,
-    actions,
-  };
-}
-
-// What dependencies you are bringing in that don't absorb into the semver ranges at the top level
-function notBeingAbsorbedByTopLevel(
-  dependencyTree: IArboristNode
-): ISuggestion {
-  const notAbsorbed = [];
-
-  for (const node of getValues(dependencyTree)) {
-    const topLevelPath = `node_modules/${node.name}`;
-
-    // don't count dependencies that are topLevel dependencies
-    if (topLevelPath === node.path) continue;
-
-    const topLevelPackage = dependencyTree.meta.data.packages[topLevelPath];
-
-    // if there is no top level package there was no need to hoist it to deduplicate as there is only one package in the tree
-    if (!topLevelPackage) continue;
-
-    if (topLevelPackage && topLevelPackage.version !== node.version) {
-      const breadcrumb = getBreadcrumb(node);
-      const size = getDirectorySize({
-        directory: node.path,
-        exclude: new RegExp(path.resolve(node.path, "node_modules")),
-      });
-
-      notAbsorbed.push({
-        message: `"${
-          node.name
-        }" (${breadcrumb}) not absorbed because top level dep is "${
-          topLevelPackage.version
-        }" and this is "${
-          node.version
-        }". This takes up an additional ${humanFileSize(size)}.`,
-        meta: {
-          breadcrumb,
-          name: node.name,
-          directory: node.path,
-          size,
-        },
-      });
-    }
-  }
-
-  return {
-    id: "notBeingAbsorbedByTopLevel",
-    name: "Dependencies not being absorbed",
-    message: `There are currently ${
-      notAbsorbed.length
-    } duplicate packages being installed on disk because they are not being absorbed into the top level semver range. This equates to a total of ${humanFileSize(
-      notAbsorbed.reduce((total, dep) => total + dep.meta.size, 0)
-    )}`,
-    actions: notAbsorbed.sort((a, b) => b.meta.size - a.meta.size),
-  };
-}
-
-// What percentage of your nested dependencies do you bring in that are out of date (major, minor, patch)
-function nestedDependencyFreshness(
-  dependencyTree: IArboristNode,
-  latestPackages: IDependencyMap
-): ISuggestion {
-  const outOfDate: {
-    major: IArboristNode[];
-    minor: IArboristNode[];
-    patch: IArboristNode[];
-  } = {
-    major: [],
-    minor: [],
-    patch: [],
-  };
-  let totalDeps = 0;
-
-  for (const node of getValues(dependencyTree)) {
-    totalDeps += 1;
-
-    try {
-      const diff = semverDiff(node.version, latestPackages[node.name]);
-
-      switch (diff) {
-        case "major":
-          outOfDate.major.push(node);
-          break;
-        case "minor":
-          outOfDate.minor.push(node);
-          break;
-        case "patch":
-          outOfDate.patch.push(node);
-          break;
-      }
-    } catch (ex: any) {
-      console.log(ex.message);
-    }
-  }
-
-  const actions: IAction[] = [];
-
-  outOfDate.major.forEach((node) => {
-    const { name, version, path } = node;
-    const breadcrumb = getBreadcrumb(node);
-    actions.push({
-      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a major version out of date.`,
-      meta: {
-        name,
-        directory: path,
-        breadcrumb,
-      },
-    });
-  });
-
-  outOfDate.minor.map((node) => {
-    const { name, version, path } = node;
-    const breadcrumb = getBreadcrumb(node);
-    actions.push({
-      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a minor version out of date.`,
-      meta: {
-        name,
-        directory: path,
-        breadcrumb,
-      },
-    });
-  });
-
-  outOfDate.patch.map((node) => {
-    const { name, version, path } = node;
-    const breadcrumb = getBreadcrumb(node);
-    actions.push({
-      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a patch version out of date.`,
-      meta: {
-        name,
-        directory: path,
-        breadcrumb,
-      },
-    });
-  });
-
-  return {
-    id: "nestedDependencyFreshness",
-    name: "Nested Dependency Freshness",
-    message: `Out of the total ${totalDeps} sub packages currently installed; ${
-      outOfDate.major.length
-    } major versions out of date (${(
-      (outOfDate.major.length / totalDeps) *
-      100
-    ).toFixed(2)}%), ${outOfDate.minor.length} minor versions out of date (${(
-      (outOfDate.minor.length / totalDeps) *
-      100
-    ).toFixed(2)}%), ${outOfDate.patch.length} patch versions out of date (${(
-      (outOfDate.patch.length / totalDeps) *
-      100
-    ).toFixed(2)}%)`,
-    actions,
-  };
 }
 
 async function getLatestPackages(
@@ -468,53 +83,56 @@ async function getLatestPackages(
 
 export default async function generateReport(cwd: string): Promise<IReport> {
   const arb = new Arborist({});
-  const dependencyTree: IArboristNode = await arb.loadActual();
-  const latestPackages = await getLatestPackages(dependencyTree);
+  const dependencyTreeRoot: IArboristNode = await arb.loadActual();
+  const latestPackages = await getLatestPackages(dependencyTreeRoot);
 
   const dependencies: DependenciesList = [];
 
-  if (dependencyTree.inventory.size) {
-    getValues(dependencyTree).forEach((entryInfo) => {
-      const location = path
-        .resolve(entryInfo.location)
-        .replace(path.resolve(cwd) + "/", "");
+  const dependencyValues = getValues(dependencyTreeRoot);
+  dependencyValues.forEach((entryInfo) => {
+    const location = path
+      .resolve(entryInfo.location)
+      .replace(path.resolve(cwd) + "/", "");
 
-      dependencies.push([
+    dependencies.push([
+      location,
+      {
+        breadcrumb: getBreadcrumb(entryInfo),
+        funding: entryInfo.funding,
+        homepage: entryInfo.homepage,
         location,
-        {
-          breadcrumb: getBreadcrumb(entryInfo),
-          funding: entryInfo.funding,
-          homepage: entryInfo.homepage,
-          location,
-          name: entryInfo.name,
-          size: getDirectorySize({
-            directory: entryInfo.path,
-            exclude: new RegExp(path.resolve(entryInfo.path, "node_modules")),
-          }),
-        },
-      ]);
-    });
-  }
+        name: entryInfo.name,
+        size: getDirectorySize({
+          directory: entryInfo.path,
+          exclude: new RegExp(path.resolve(entryInfo.path, "node_modules")),
+        }),
+      },
+    ]);
+  });
 
   return {
     latestPackages,
-    package: dependencyTree.package,
+    package: dependencyTreeRoot.package,
     dependencies,
     suggestions: [
       // suggestion because doesn't allow you to collapse versions (you end up with copies of what could be the same thing)
-      packagesWithPinnedVersions(dependencyTree),
+      packagesWithPinnedVersions(dependencyValues),
 
       // docs/ or tests/ is published to npm - how do you NOT publish them (use ignore file or package.json.files[]?
-      packagesWithExtraArtifacts(dependencyTree),
+      packagesWithExtraArtifacts(dependencyValues),
 
       // version range that doesn't satisfy the top level version range
-      notBeingAbsorbedByTopLevel(dependencyTree),
+      notBeingAbsorbedByTopLevel(dependencyTreeRoot, dependencyValues),
 
       // your dependencies have updatable dependencies (and how out of date; major, minor, patch)
-      nestedDependencyFreshness(dependencyTree, latestPackages),
+      nestedDependencyFreshness(dependencyValues, latestPackages),
 
       // name as nested, just top level
-      topLevelDepsFreshness(dependencyTree, latestPackages),
+      topLevelDepsFreshness(
+        dependencyTreeRoot,
+        dependencyValues,
+        latestPackages
+      ),
     ],
   };
 }

--- a/packages/module-detective/src/lib/suggestors/index.ts
+++ b/packages/module-detective/src/lib/suggestors/index.ts
@@ -1,0 +1,13 @@
+import nestedDependencyFreshness from "./nested-deps-freshness";
+import notBeingAbsorbedByTopLevel from "./not-absorbed-by-top-level";
+import packagesWithExtraArtifacts from "./packages-with-artifacts";
+import packagesWithPinnedVersions from "./packages-with-pinned-versions";
+import topLevelDepsFreshness from "./top-level-deps-freshness";
+
+export {
+  packagesWithPinnedVersions,
+  packagesWithExtraArtifacts,
+  topLevelDepsFreshness,
+  nestedDependencyFreshness,
+  notBeingAbsorbedByTopLevel,
+};

--- a/packages/module-detective/src/lib/suggestors/nested-deps-freshness.ts
+++ b/packages/module-detective/src/lib/suggestors/nested-deps-freshness.ts
@@ -4,7 +4,7 @@ import { ISuggestion, IAction, IArboristNode } from "../../types";
 import { getBreadcrumb } from "../utils/breadcrumb";
 
 // What percentage of your nested dependencies do you bring in that are out of date (major, minor, patch)
-export function nestedDependencyFreshness(
+export default function nestedDependencyFreshness(
   dependencyValues: IArboristNode[],
   latestPackages: IDependencyMap
 ): ISuggestion {

--- a/packages/module-detective/src/lib/suggestors/nested-deps-freshness.ts
+++ b/packages/module-detective/src/lib/suggestors/nested-deps-freshness.ts
@@ -1,0 +1,102 @@
+import { IDependencyMap } from "package-json-type";
+import semverDiff from "semver/functions/diff";
+import { ISuggestion, IAction, IArboristNode } from "../../types";
+import { getBreadcrumb } from "../utils/breadcrumb";
+
+// What percentage of your nested dependencies do you bring in that are out of date (major, minor, patch)
+export function nestedDependencyFreshness(
+  dependencyValues: IArboristNode[],
+  latestPackages: IDependencyMap
+): ISuggestion {
+  const outOfDate: {
+    major: IArboristNode[];
+    minor: IArboristNode[];
+    patch: IArboristNode[];
+  } = {
+    major: [],
+    minor: [],
+    patch: [],
+  };
+  let totalDeps = 0;
+
+  for (const node of dependencyValues) {
+    totalDeps += 1;
+
+    try {
+      const diff = semverDiff(node.version, latestPackages[node.name]);
+
+      switch (diff) {
+        case "major":
+          outOfDate.major.push(node);
+          break;
+        case "minor":
+          outOfDate.minor.push(node);
+          break;
+        case "patch":
+          outOfDate.patch.push(node);
+          break;
+      }
+    } catch (ex) {
+      console.log(ex);
+    }
+  }
+
+  const actions: IAction[] = [];
+
+  outOfDate.major.forEach((node) => {
+    const { name, version, path } = node;
+    const breadcrumb = getBreadcrumb(node);
+    actions.push({
+      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a major version out of date.`,
+      meta: {
+        name,
+        directory: path,
+        breadcrumb,
+      },
+    });
+  });
+
+  outOfDate.minor.map((node) => {
+    const { name, version, path } = node;
+    const breadcrumb = getBreadcrumb(node);
+    actions.push({
+      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a minor version out of date.`,
+      meta: {
+        name,
+        directory: path,
+        breadcrumb,
+      },
+    });
+  });
+
+  outOfDate.patch.map((node) => {
+    const { name, version, path } = node;
+    const breadcrumb = getBreadcrumb(node);
+    actions.push({
+      message: `"${name}@${version}" is required at "${breadcrumb}", the latest is ${latestPackages[name]}. This is a patch version out of date.`,
+      meta: {
+        name,
+        directory: path,
+        breadcrumb,
+      },
+    });
+  });
+
+  return {
+    id: "nestedDependencyFreshness",
+    name: "Nested Dependency Freshness",
+    message: `Out of the total ${totalDeps} sub packages currently installed; ${
+      outOfDate.major.length
+    } major versions out of date (${(
+      (outOfDate.major.length / totalDeps) *
+      100
+    ).toFixed(2)}%), ${outOfDate.minor.length} minor versions out of date (${(
+      (outOfDate.minor.length / totalDeps) *
+      100
+    ).toFixed(2)}%), ${outOfDate.patch.length} patch versions out of date (${(
+      (outOfDate.patch.length / totalDeps) *
+      100
+    ).toFixed(2)}%)`,
+    actions,
+  };
+}

--- a/packages/module-detective/src/lib/suggestors/not-absorbed-by-top-level.ts
+++ b/packages/module-detective/src/lib/suggestors/not-absorbed-by-top-level.ts
@@ -5,7 +5,7 @@ import { getDirectorySize } from "../utils/disk";
 import humanFileSize from "../utils/human-file-size";
 
 // What dependencies you are bringing in that don't absorb into the semver ranges at the top level
-export function notBeingAbsorbedByTopLevel(
+export default function notBeingAbsorbedByTopLevel(
   root: IArboristNode,
   dependencyValues: IArboristNode[]
 ): ISuggestion {

--- a/packages/module-detective/src/lib/suggestors/not-absorbed-by-top-level.ts
+++ b/packages/module-detective/src/lib/suggestors/not-absorbed-by-top-level.ts
@@ -1,0 +1,60 @@
+import path from "path";
+import { IArboristNode, ISuggestion } from "../../types";
+import { getBreadcrumb } from "../utils/breadcrumb";
+import { getDirectorySize } from "../utils/disk";
+import humanFileSize from "../utils/human-file-size";
+
+// What dependencies you are bringing in that don't absorb into the semver ranges at the top level
+export function notBeingAbsorbedByTopLevel(
+  root: IArboristNode,
+  dependencyValues: IArboristNode[]
+): ISuggestion {
+  const notAbsorbed = [];
+
+  for (const node of dependencyValues) {
+    const topLevelPath = `node_modules/${node.name}`;
+
+    // don't count dependencies that are topLevel dependencies
+    if (topLevelPath === node.path) continue;
+
+    const topLevelPackage = root.meta.data.packages[topLevelPath];
+
+    // if there is no top level package there was no need to hoist it to deduplicate as there is only one package in the tree
+    if (!topLevelPackage) continue;
+
+    if (topLevelPackage && topLevelPackage.version !== node.version) {
+      const breadcrumb = getBreadcrumb(node);
+      const size = getDirectorySize({
+        directory: node.path,
+        exclude: new RegExp(path.resolve(node.path, "node_modules")),
+      });
+
+      notAbsorbed.push({
+        message: `"${
+          node.name
+        }" (${breadcrumb}) not absorbed because top level dep is "${
+          topLevelPackage.version
+        }" and this is "${
+          node.version
+        }". This takes up an additional ${humanFileSize(size)}.`,
+        meta: {
+          breadcrumb,
+          name: node.name,
+          directory: node.path,
+          size,
+        },
+      });
+    }
+  }
+
+  return {
+    id: "notBeingAbsorbedByTopLevel",
+    name: "Dependencies not being absorbed",
+    message: `There are currently ${
+      notAbsorbed.length
+    } duplicate packages being installed on disk because they are not being absorbed into the top level semver range. This equates to a total of ${humanFileSize(
+      notAbsorbed.reduce((total, dep) => total + dep.meta.size, 0)
+    )}`,
+    actions: notAbsorbed.sort((a, b) => b.meta.size - a.meta.size),
+  };
+}

--- a/packages/module-detective/src/lib/suggestors/packages-with-artifacts.ts
+++ b/packages/module-detective/src/lib/suggestors/packages-with-artifacts.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import path from "path";
+import { IArboristNode, ISuggestion } from "../../types";
+import { getBreadcrumb } from "../utils/breadcrumb";
+import { getDirectorySize } from "../utils/disk";
+import humanFileSize from "../utils/human-file-size";
+
+export function packagesWithExtraArtifacts(
+  dependencyValues: IArboristNode[]
+): ISuggestion {
+  const extraArtifacts = [];
+
+  for (const node of dependencyValues) {
+    const breadcrumb = getBreadcrumb(node);
+
+    if (fs.existsSync(path.resolve(node.path, "docs"))) {
+      const size = getDirectorySize({
+        directory: node.path,
+        exclude: new RegExp(path.resolve(node.path, "docs")),
+      });
+
+      extraArtifacts.push({
+        message: `"${
+          node.name
+        }" (${breadcrumb}) has a "docs" folder which is not necessary for production usage ${humanFileSize(
+          size
+        )}.`,
+        meta: {
+          breadcrumb,
+          name: node.name,
+          directory: node.path,
+          size,
+        },
+      });
+    }
+
+    if (fs.existsSync(path.resolve(node.path, "tests"))) {
+      const size = getDirectorySize({
+        directory: node.path,
+        exclude: new RegExp(path.resolve(node.path, "tests")),
+      });
+
+      extraArtifacts.push({
+        message: `"${
+          node.name
+        }" (${breadcrumb}) has a "tests" folder which is not necessary for production usage ${humanFileSize(
+          size
+        )}.`,
+        meta: {
+          breadcrumb,
+          name: node.name,
+          directory: node.path,
+          size,
+        },
+      });
+    }
+  }
+
+  return {
+    id: "packagesWithExtraArtifacts",
+    name: "Packages with extra artifacts",
+    message: `There are currently ${
+      new Set(extraArtifacts.map((action) => action.meta.name)).size
+    } packages with artifacts that are superflous and are not necessary for production usage. ${humanFileSize(
+      extraArtifacts.reduce((total, dep) => total + dep.meta.size, 0)
+    )}`,
+    actions: extraArtifacts.sort((a, b) => b.meta.size - a.meta.size),
+  };
+}

--- a/packages/module-detective/src/lib/suggestors/packages-with-artifacts.ts
+++ b/packages/module-detective/src/lib/suggestors/packages-with-artifacts.ts
@@ -5,7 +5,7 @@ import { getBreadcrumb } from "../utils/breadcrumb";
 import { getDirectorySize } from "../utils/disk";
 import humanFileSize from "../utils/human-file-size";
 
-export function packagesWithExtraArtifacts(
+export default function packagesWithExtraArtifacts(
   dependencyValues: IArboristNode[]
 ): ISuggestion {
   const extraArtifacts = [];

--- a/packages/module-detective/src/lib/suggestors/packages-with-pinned-versions.ts
+++ b/packages/module-detective/src/lib/suggestors/packages-with-pinned-versions.ts
@@ -4,7 +4,7 @@ import { getBreadcrumb } from "../utils/breadcrumb";
 import { getDirectorySize } from "../utils/disk";
 import humanFileSize from "../utils/human-file-size";
 
-export function packagesWithPinnedVersions(
+export default function packagesWithPinnedVersions(
   dependencyValues: IArboristNode[]
 ): ISuggestion {
   const packagedWithPinned = [];

--- a/packages/module-detective/src/lib/suggestors/packages-with-pinned-versions.ts
+++ b/packages/module-detective/src/lib/suggestors/packages-with-pinned-versions.ts
@@ -1,0 +1,54 @@
+import path from "path";
+import { IArboristNode, ISuggestion } from "../../types";
+import { getBreadcrumb } from "../utils/breadcrumb";
+import { getDirectorySize } from "../utils/disk";
+import humanFileSize from "../utils/human-file-size";
+
+export function packagesWithPinnedVersions(
+  dependencyValues: IArboristNode[]
+): ISuggestion {
+  const packagedWithPinned = [];
+
+  for (const node of dependencyValues) {
+    const breadcrumb = getBreadcrumb(node);
+
+    const { dependencies } = node.package ?? {};
+    for (const dependencyName in dependencies) {
+      if (
+        // might need to check the logic on this; "~" means "takes patches"
+        // check node-semver to see the logc
+        dependencies[dependencyName].substring(0, 1) === "~"
+      ) {
+        try {
+          const size = getDirectorySize({
+            directory: node.edgesOut.get(dependencyName)?.to.path ?? "",
+            exclude: new RegExp(path.resolve(node.path, "docs")),
+          });
+
+          packagedWithPinned.push({
+            message: `"${node.name}" (${breadcrumb}) has a pinned version for ${dependencyName}@${dependencies[dependencyName]} that will never collapse.`,
+            meta: {
+              breadcrumb,
+              name: node.name,
+              directory: node.path,
+              size,
+            },
+          });
+        } catch (ex) {
+          console.log(ex);
+        }
+      }
+    }
+  }
+
+  return {
+    id: "packagesWithPinnedVersions",
+    name: "Packages with pinned dependencies",
+    message: `There are currently ${
+      new Set(packagedWithPinned.map((action) => action.meta.name)).size
+    } packages with pinned versions which will never collapse those dependencies causing an additional ${humanFileSize(
+      packagedWithPinned.reduce((total, dep) => total + dep.meta.size, 0)
+    )}`,
+    actions: packagedWithPinned.sort((a, b) => b.meta.size - a.meta.size),
+  };
+}

--- a/packages/module-detective/src/lib/suggestors/top-level-deps-freshness.ts
+++ b/packages/module-detective/src/lib/suggestors/top-level-deps-freshness.ts
@@ -3,7 +3,7 @@ import { IArboristNode, ISuggestion, IVersionMeta, IAction } from "../../types";
 import { getBreadcrumb } from "../utils/breadcrumb";
 import semverDiff from "semver/functions/diff";
 
-export function topLevelDepsFreshness(
+export default function topLevelDepsFreshness(
   root: IArboristNode,
   dependencyValues: IArboristNode[],
   latestPackages: IDependencyMap

--- a/packages/module-detective/src/lib/suggestors/top-level-deps-freshness.ts
+++ b/packages/module-detective/src/lib/suggestors/top-level-deps-freshness.ts
@@ -1,0 +1,120 @@
+import { IDependencyMap } from "package-json-type";
+import { IArboristNode, ISuggestion, IVersionMeta, IAction } from "../../types";
+import { getBreadcrumb } from "../utils/breadcrumb";
+import semverDiff from "semver/functions/diff";
+
+export function topLevelDepsFreshness(
+  root: IArboristNode,
+  dependencyValues: IArboristNode[],
+  latestPackages: IDependencyMap
+): ISuggestion {
+  const dependencies = Object.assign(
+    {},
+    Object.assign({}, root.package.devDependencies || {}),
+    root.package.dependencies || {}
+  );
+  const totalDeps = Object.keys(dependencies).length;
+  const outOfDate: {
+    major: IVersionMeta[];
+    minor: IVersionMeta[];
+    patch: IVersionMeta[];
+  } = { major: [], minor: [], patch: [] };
+
+  for (const dependency in dependencies) {
+    try {
+      const topLevelPackage = dependencyValues.find(
+        (dependency) => dependency.location === `node_modules/${dependency}`
+      );
+      if (topLevelPackage) {
+        const breadcrumb = getBreadcrumb(topLevelPackage);
+        const diff = semverDiff(
+          topLevelPackage.version,
+          latestPackages[topLevelPackage.name]
+        );
+
+        switch (diff) {
+          case "major":
+            outOfDate.major.push({
+              name: dependency,
+              directory: `node_module/${dependency}`,
+              version: topLevelPackage.version,
+              breadcrumb,
+            });
+            break;
+          case "minor":
+            outOfDate.minor.push({
+              name: dependency,
+              directory: `node_module/${dependency}`,
+              version: topLevelPackage.version,
+              breadcrumb,
+            });
+            break;
+          case "patch":
+            outOfDate.patch.push({
+              name: dependency,
+              directory: `node_module/${dependency}`,
+              version: topLevelPackage.version,
+              breadcrumb,
+            });
+            break;
+        }
+      }
+    } catch (ex) {
+      // TODO: better debugging messaging here
+      console.log(ex);
+    }
+  }
+
+  const actions: IAction[] = [];
+
+  outOfDate.major.forEach(({ name, directory, version, breadcrumb }) => {
+    actions.push({
+      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a major version out of date.`,
+      meta: {
+        name,
+        directory,
+        breadcrumb,
+      },
+    });
+  });
+
+  outOfDate.minor.forEach(({ name, directory, version, breadcrumb }) => {
+    actions.push({
+      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a minor version out of date.`,
+      meta: {
+        name,
+        directory,
+        breadcrumb,
+      },
+    });
+  });
+
+  outOfDate.patch.forEach(({ name, directory, version, breadcrumb }) => {
+    actions.push({
+      message: `"${name}@${version}" is required as a direct dependency, the latest is ${latestPackages[name]}. This is a patch version out of date.`,
+      meta: {
+        name,
+        directory,
+        breadcrumb,
+      },
+    });
+  });
+
+  return {
+    id: "topLevelDepsFreshness",
+    name: "Top Level Dependency Freshness",
+    message: `Out of the total ${totalDeps} explicit dependencies defined in the package.json; ${
+      outOfDate.major.length
+    } major versions out of date (${(
+      (outOfDate.major.length / totalDeps) *
+      100
+    ).toFixed(2)}%), ${outOfDate.minor.length} minor versions out of date (${(
+      (outOfDate.minor.length / totalDeps) *
+      100
+    ).toFixed(2)}%), ${outOfDate.patch.length} patch versions out of date (${(
+      (outOfDate.patch.length / totalDeps) *
+      100
+    ).toFixed(2)}%)`,
+    actions,
+  };
+}

--- a/packages/module-detective/src/lib/utils/breadcrumb.ts
+++ b/packages/module-detective/src/lib/utils/breadcrumb.ts
@@ -1,0 +1,28 @@
+import { IArboristNode } from "../../types";
+
+export function getBreadcrumb(node: IArboristNode): string {
+  const bread: string[] = [];
+
+  function walk(node: IArboristNode): string[] {
+    if (bread.includes(node.name)) {
+      return bread;
+    }
+
+    if (node.edgesIn) {
+      const [edge] = [...node.edgesIn.values()];
+
+      if (edge && edge.from) {
+        bread.push(edge.name);
+
+        return walk(edge.from);
+      } else {
+        // we have gotten to the root project, don't push the root project name
+        return bread;
+      }
+    } else {
+      return bread;
+    }
+  }
+
+  return walk(node).reverse().join("#");
+}

--- a/packages/module-detective/src/lib/utils/disk.ts
+++ b/packages/module-detective/src/lib/utils/disk.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+export function getAllFiles(
+  dirPath: string,
+  exclude: RegExp,
+  arrayOfFiles?: string[]
+) {
+  const files = fs.readdirSync(dirPath);
+
+  const _arrayOfFiles = arrayOfFiles || [];
+
+  files.forEach(function (file: string) {
+    const fullPath = path.join(dirPath, file);
+
+    try {
+      if (fs.statSync(fullPath).isDirectory()) {
+        arrayOfFiles = getAllFiles(fullPath, exclude, arrayOfFiles);
+      } else {
+        if (!exclude || (exclude && !exclude.test(fullPath))) {
+          _arrayOfFiles.push(fullPath);
+        }
+      }
+    } catch (ex: any) {
+      console.log(ex.message);
+    }
+  });
+
+  return _arrayOfFiles;
+}
+
+export function getDirectorySize({
+  directory,
+  exclude,
+}: {
+  directory: string;
+  exclude: RegExp;
+}) {
+  const arrayOfFiles = getAllFiles(directory, exclude);
+
+  return arrayOfFiles
+    .map((filePath) => fs.statSync(filePath).size)
+    .reduce((a, b) => a + b, 0);
+}

--- a/packages/module-detective/src/lib/utils/human-file-size.ts
+++ b/packages/module-detective/src/lib/utils/human-file-size.ts
@@ -1,4 +1,8 @@
-export function humanFileSize(bytes: number, si = false, dp = 1): string {
+export default function humanFileSize(
+  bytes: number,
+  si = false,
+  dp = 1
+): string {
   const thresh = si ? 1000 : 1024;
 
   if (Math.abs(bytes) < thresh) {

--- a/packages/module-detective/src/types.ts
+++ b/packages/module-detective/src/types.ts
@@ -1,5 +1,15 @@
-export type BasicJSON = Record<string, string>;
+import { IDependencyMap, IPackageJson } from "package-json-type";
+
 export type DependenciesList = [string, IDependency][];
+
+export interface IArboristEdge {
+  type: Set<string>;
+  name: string;
+  spec: string;
+  accept: string;
+  from: IArboristNode;
+  to: IArboristNode;
+}
 
 // a very weak definition for https://github.com/npm/arborist/blob/48eb8fa01ea1cd1f89f47379b1ba4881a8bb9fbc/lib/node.js
 export interface IArboristNode {
@@ -7,8 +17,8 @@ export interface IArboristNode {
   dev: boolean;
   devOptional: boolean;
   dummy: boolean;
-  edgesIn: Set<IArboristNode>;
-  edgesOut: Map<string, IArboristNode>;
+  edgesIn: Set<IArboristEdge>;
+  edgesOut: Map<string, IArboristEdge>;
   errors: Array<any>;
   extraneous: boolean;
   fsChildren: Set<IArboristNode>;
@@ -26,22 +36,22 @@ export interface IArboristNode {
   resolved: unknown | null;
   sourceReference: unknown | null;
   tops: Set<IArboristNode>;
-  package: BasicJSON;
+  package: IPackageJson;
   packageName: string;
   isLink: boolean;
   homepage: string;
   funding: string;
+  version: string;
+  meta: any;
 }
 
 export interface IDependency {
-  name: string;
   breadcrumb: string;
-  size: number;
-  location: string;
-  // url to dependecy
-  homepage?: string;
-  // funding url
   funding?: string;
+  homepage?: string;
+  location: string;
+  name: string;
+  size: number;
 }
 
 export interface IActionMeta {
@@ -71,8 +81,8 @@ export interface ISuggestion {
 }
 
 export interface IReport {
-  latestPackages: BasicJSON;
-  package: BasicJSON;
+  latestPackages: IDependencyMap;
+  package: IPackageJson;
   dependencies: DependenciesList;
   suggestions: ISuggestion[];
 }


### PR DESCRIPTION
Kind of big changes:
1. adding typing for package.json and IArboristEdge
2. moving utils into their own directory
3. moving "suggestors" into their own directory
4. removing getEntries and only using getValues
5. passing in dependencyTreeRoot and dependencyValues as separate params to the suggestors